### PR TITLE
Implement missing handler error

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ type errorOptions = {
 }
 ```
 
+### Default Error Causes
+
+The function returned by `errorCauses()` knows a default error. You will need to supply your own handlers to handle this error.
+
+#### `MissingHandler`
+
+`MissingHandler` is thrown when the supplied error has no cause. This is likely
+because the error was not created using `createError()`.
+
+```js
+const MissingHandler = {
+  name: "MissingHandler",
+  message: "Missing handler for cause",
+};
+```
+
 ## Sponsors
 
 This project is made possible by [EricElliottJS.com](https://ericelliottjs.com) and [DevAnywhere.io](https://devanywhere.io). If you would like to sponsore this project as well, [reach out](https://devanywhere.io/help?subject=Sponsor+Error+Causes).

--- a/src/error-causes.js
+++ b/src/error-causes.js
@@ -26,6 +26,11 @@ const createError = ({ message, ...rest } = {}) => {
   return error;
 };
 
+const MissingHandler = {
+  name: "MissingHandler",
+  message: "Missing handler for cause",
+};
+
 /**
  * @param {object} causes - A map of error causes keyed by error name
  * @returns [object, function]
@@ -43,11 +48,12 @@ const errorCauses = (causes = {}) => {
     const { cause } = error;
     const handler = handlers[cause.name];
 
-    // if (!handler) throw createError({
-    //   ...MissingCause,
-    //   message: `${ MissingCause.message }: ${ error }`,
-    //   cause: error,
-    // });
+    if (!handler)
+      throw createError({
+        ...MissingHandler,
+        message: `${MissingHandler.message}: ${error.cause.name}`,
+        cause: error,
+      });
 
     return handler(error);
   };


### PR DESCRIPTION
This PR addresses the TODOs in the tests and has the `handleErrors` function throw a `MissingHandler` error when the respective handler isn't configured. (There is a follow up PR #8 for `MissingCause`, too.)

It also renames the return values like #6 proposes, to make the tests easier to read.