### PR TITLE
Handle errors without a cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Or install with yarn:
 yarn add error-causes
 ```
 
-
 ## Why Error Causes?
 
 For every asynchronous API, it's a good idea to define and document the various error causes that might arise. How can a caller distinguish an error caused by bad input from an error caused by a network failure?
@@ -135,6 +134,33 @@ type errorOptions = {
   stack: String,
   ...rest: * // Mixed types allowed
 }
+```
+
+### Default Error Causes
+
+The function returned by `errorCauses()` knows 2 default errors. You will need to supply your own handlers to handle these errors.
+
+#### `MissingCause`
+
+`MissingCause` is thrown when the supplied error has no cause. This is likely
+because the error was not created using `createError()`.
+
+```js
+const MissingCause = {
+  name: "MissingCause",
+  message: "Error is missing a cause",
+};
+```
+
+#### `MissingCauseName`
+
+`MissingCause` is thrown when the supplied error's cause has no name. This is likely because the error was not created using `createError()`.
+
+```js
+const MissingCauseName = {
+  name: "MissingCauseName",
+  message: "Error's cause is missing a name",
+};
 ```
 
 ## Sponsors

--- a/src/error-causes.js
+++ b/src/error-causes.js
@@ -26,6 +26,15 @@ const createError = ({ message, ...rest } = {}) => {
   return error;
 };
 
+const MissingCause = {
+  name: "MissingCause",
+  message: "Error is missing a cause",
+};
+const MissingCauseName = {
+  name: "MissingCauseName",
+  message: "Error's cause is missing a name",
+};
+
 /**
  * @param {object} causes - A map of error causes keyed by error name
  * @returns [object, function]
@@ -41,6 +50,21 @@ const errorCauses = (causes = {}) => {
 
   const handleErrors = (handlers) => (error) => {
     const { cause } = error;
+
+    if (!cause)
+      throw createError({
+        ...MissingCause,
+        message: `${MissingCause.message}: ${error.name}. Did you forget to create the error with createError()?`,
+        cause: error,
+      });
+
+    if (!cause.name)
+      throw createError({
+        ...MissingCauseName,
+        message: `${MissingCauseName.message}: ${error.name}. Did you forget to create the error with createError()?`,
+        cause: error,
+      });
+
     const handler = handlers[cause.name];
 
     // if (!handler) throw createError({


### PR DESCRIPTION
This PR adds runtime guards against errors that can't be processed by the function returned from `errorCauses` because they're missing a `.cause`, or `.cause.name`: `MissingCause` and `MissingCauseName`.

It also adds information about these errors to the `README.md`.